### PR TITLE
Fix iserv-proxy build on windows

### DIFF
--- a/Main.hs
+++ b/Main.hs
@@ -88,14 +88,14 @@ main = do
   hSetBuffering stdout LineBuffering
 
   args <- getArgs
-  (wfd1, rfd2, host_ip, port, rest) <-
+  (outh, inh, host_ip, port, rest) <-
       case args of
         arg0:arg1:arg2:arg3:rest -> do
-            let wfd1 = read arg0
-                rfd2 = read arg1
-                ip   = arg2
+            outh <- readGhcHandle arg0
+            inh <- readGhcHandle arg1
+            let ip   = arg2
                 port = read arg3
-            return (wfd1, rfd2, ip, port, rest)
+            return (outh, inh, ip, port, rest)
         _ -> dieWithUsage
 
   let verbose = "-v" `elem` rest
@@ -105,10 +105,7 @@ main = do
     dieWithUsage
 
   when verbose $
-    printf "GHC iserv starting (in: %d; out: %d)\n"
-      (fromIntegral rfd2 :: Int) (fromIntegral wfd1 :: Int)
-  inh  <- getGhcHandle rfd2
-  outh <- getGhcHandle wfd1
+    printf "GHC iserv starting (in: %s; out: %s)\n" (show inh) (show outh)
   installSignalHandlers
 #if MIN_VERSION_ghci(9,13,0)
   in_pipe <- mkPipeFromHandles inh outh


### PR DESCRIPTION
Not sure why this wasn't a problem before. 
Maybe because haskell.nix does per-component builds so building the host side for windows basically never happened?

Fixes
```
Building executable 'iserv-proxy' for iserv-proxy-9.3...
[1 of 1] Compiling Main             ( Main.hs, dist/build/iserv-proxy/iserv-proxy-tmp/Main.o )
Main.hs:94:24: error: [GHC-39999]
    • No instance for ‘Read
                         (ghc-internal-9.1202.0:GHC.Internal.Ptr.Ptr ())’
        arising from a use of ‘read’
    • In the expression: read arg0
      In an equation for ‘wfd1’: wfd1 = read arg0
      In a stmt of a 'do' block:
        let wfd1 = read arg0
            rfd2 = read arg1
            ip = arg2
            port = read arg3
   |
94 |             let wfd1 = read arg0
   |                        ^^^^

Main.hs:109:8: error: [GHC-39999]
    • No instance for ‘Integral
                         (ghc-internal-9.1202.0:GHC.Internal.Ptr.Ptr ())’
        arising from a use of ‘fromIntegral’
    • In the second argument of ‘printf’, namely
        ‘(fromIntegral rfd2 :: Int)’
      In the second argument of ‘($)’, namely
        ‘printf
           "GHC iserv starting (in: %d; out: %d)\n" (fromIntegral rfd2 :: Int)
           (fromIntegral wfd1 :: Int)’
      In a stmt of a 'do' block:
        when verbose
          $ printf
              "GHC iserv starting (in: %d; out: %d)\n" (fromIntegral rfd2 :: Int)
              (fromIntegral wfd1 :: Int)
    |
109 |       (fromIntegral rfd2 :: Int) (fromIntegral wfd1 :: Int)
```

